### PR TITLE
use cloudfront-log-reader v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "log-reader": "0.0.0",
     "sphericalmercator": "~1.0.2",
-    "cloudfront-log-reader": "0.1.1",
+    "cloudfront-log-reader": "0.2.0",
     "polyline": "0.0.3",
     "sphericalmercator": "~1.0.2"
   },


### PR DESCRIPTION
Use cloudfront-log-reader v0.2.0 (see https://github.com/mapbox/cloudfront-log-reader/pull/3). In replay, if a URI has a query string, it will be returned in addition to the URI stem.


/cc @ianshward 