### PR TITLE
Fix context bug in cloudfront-log-reader

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "log-reader": "0.0.0",
     "sphericalmercator": "~1.0.2",
-    "cloudfront-log-reader": "0.2.1",
+    "cloudfront-log-reader": "mapbox/cloudfront-log-reader#context-bug",
     "polyline": "0.0.3",
     "sphericalmercator": "~1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "log-reader": "0.0.0",
     "sphericalmercator": "~1.0.2",
-    "cloudfront-log-reader": "mapbox/cloudfront-log-reader#context-bug",
+    "cloudfront-log-reader": "0.4.0",
     "polyline": "0.0.3",
     "sphericalmercator": "~1.0.2"
   },


### PR DESCRIPTION
The effect of this bug was that only a single log file would ever get used.